### PR TITLE
Fix `undefined method `[]' for nil:NilClass (NoMethodError)`

### DIFF
--- a/cmd/brew-autoremove
+++ b/cmd/brew-autoremove
@@ -37,6 +37,8 @@ info.each { |f|
 		:requested => requested,
 		:rdeps => [],
 	}
+
+	f['aliases'].each { |a| graph[a] = graph[f['full_name']] unless graph.has_key?(a) }
 }
 
 # Populate rdeps.


### PR DESCRIPTION
Make graph entries for aliases to avoid nil pointer errors

Some formulae refer to dependencies by alias, e.g., `rbenv` relies on `openssl`,
which is an alias for `openssl@1.1` as returned by `brew info`.