### PR TITLE
Dependency computation should only consider installed packages

### DIFF
--- a/cmd/brew-autoremove
+++ b/cmd/brew-autoremove
@@ -43,7 +43,12 @@ info.each { |f|
 
 # Populate rdeps.
 info.each { |f|
-	deps = f['installed'].map{|ver| ver['runtime_dependencies'].map{|dep| dep['full_name']}}.flatten.sort.uniq
+	deps = f['installed'].reduce([]) { |memo, ver|
+		ver['runtime_dependencies'].
+			map { |dep| dep['full_name'] }.
+			select { |name| graph.has_key?(name) }.
+			concat(memo)
+	}.uniq.sort
 
 	deps.each { |dep|
 		graph[dep][:rdeps].push(f['full_name'])


### PR DESCRIPTION
We need to filter `runtime_dependencies` to include packages that are actually installed.

This can happen if some packages were manually removed. Filtering prevents a nil pointer error being thrown during the computation of dependencies.